### PR TITLE
Added jacoco profile

### DIFF
--- a/bookstore/pom.xml
+++ b/bookstore/pom.xml
@@ -97,7 +97,41 @@
 					<artifactId>maven-project-info-reports-plugin</artifactId>
 					<version>3.6.1</version>
 				</plugin>
+				<plugin>
+					<groupId>org.jacoco</groupId>
+					<artifactId>jacoco-maven-plugin</artifactId>
+					<version>0.8.12</version>
+					<configuration>
+						<excludes>
+							<exclude>**/model/*</exclude>
+						</excludes>
+					</configuration>
+					<executions>
+						<execution>
+							<goals>
+								<!-- binds by default to the phase "initialize" -->
+								<goal>prepare-agent</goal>
+								<!-- binds by default to the phase "verify" -->
+								<goal>report</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>
+	<profiles>
+		<profile>
+			<id>jacoco</id>
+			<build>
+				<plugins>
+					<plugin>
+						<!-- configured in pluginManagement -->
+						<groupId>org.jacoco</groupId>
+						<artifactId>jacoco-maven-plugin</artifactId>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
The configuration is the following:
- Added the plugin and bind it by default to initialize (prepare-agent) and verify (report).
- Excluded model classes from coverage
- Created a profile named jacoco that activates the profile.

Running mvn clean verify -Pjacoco will execute tests and generates the report in target/site/jacoco.

Note that the build will not fail if the code coverage is not at a certain level because it is not configured to do so. It will be done by coveralls in future commits.
Signed-off-by: Christian Mancini <mancinichristian00@gmail.com>