### PR TITLE
19 pit on ci and report generation

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -3,6 +3,7 @@ name: Java CI with Maven in Linux
 on:
     push:
     pull_request:
+permissions: write-all
 jobs:
     build:
         runs-on: ubuntu-24.04

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -57,3 +57,4 @@ jobs:
               with:
                 name: pit-report-jdk-11
                 path: '**/target/pit-reports'
+                compression-level: 9

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -3,7 +3,8 @@ name: Java CI with Maven in Linux
 on:
     push:
     pull_request:
-permissions: write-all
+permissions:
+    contents: write
 jobs:
     build:
         runs-on: ubuntu-24.04
@@ -61,7 +62,7 @@ jobs:
                 compression-level: 9
             - name: Upload Pit report to GitHub Pages
               if: ${{ matrix.java == 11 }}
-              uses: peaceiris/actions-gh-pages@v3
+              uses: peaceiris/actions-gh-pages@v4
               with:
                 github_token: ${{ secrets.GITHUB_TOKEN }}
                 publish_dir: '**/target/pit-reports'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -58,3 +58,9 @@ jobs:
                 name: pit-report-jdk-11
                 path: '**/target/pit-reports'
                 compression-level: 9
+            - name: Upload Pit report to GitHub Pages
+              if: ${{ matrix.java == 11 }}
+              uses: peaceiris/actions-gh-pages@v3
+              with:
+                github_token: ${{ secrets.GITHUB_TOKEN }}
+                publish_dir: '**/target/pit-reports'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -39,7 +39,7 @@ jobs:
               if: ${{ matrix.java == 11 }}
               uses: coverallsapp/github-action@v2
               env:
-                github-token: ${{ secrets.COVERALLS_TOKEN }}
+                github-token: ${{ secrets.GITHUB_TOKEN }}
             - name: Generate JUnit Report
               run: mvn surefire-report:report-only site:site -DgenerateReports=false
               working-directory: ${{ env.workdir }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,7 +15,7 @@ jobs:
                     - java: 17
                     - java: 11
                       additional-maven-args: >
-                        -Pjacoco
+                        -Pjacoco,mutation-testing
             fail-fast: false
         name: Buil with Java ${{ matrix.java }} on ubuntu-24.04
         steps:
@@ -36,7 +36,7 @@ jobs:
               run: mvn clean verify ${{ matrix.additional-maven-args }}
               working-directory: ${{ env.workdir }}
             - name: Coveralls
-              if: contains(matrix.additional-maven-args, '-Pjacoco')
+              if: ${{ matrix.java == 11 }}
               uses: coverallsapp/github-action@v2
               env:
                 github-token: ${{ secrets.COVERALLS_TOKEN }}
@@ -51,3 +51,9 @@ jobs:
               with:
                 name: surefire-report-jdk-${{ matrix.java }}
                 path: '**/target/reports'
+            - name: Archive mutation report
+              if: ${{ matrix.java == 11 }}
+              uses: actions/upload-artifact@v4
+              with:
+                name: pit-report-jdk-11
+                path: '**/target/pit-reports'


### PR DESCRIPTION
Added maven profile for pit on CI and uploaded report as artifact and on github pages.
Report is accessible from here: https://cmancio00.github.io/poc-bookstore

Note that we needed to add write permissions and configure pages to deploy from branch gh-pages (default of the action) and choos the root folder